### PR TITLE
simplify _customAction logic and add support for a new action - "popup"

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,8 +508,8 @@ The `tileOnRow:` is **not required** but optional. If you do not set this, the c
 
 | Name | Type | Default | Supported options | Description |
 | ----------------- | ------ | -------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `action` | string | `toggle` | `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url` | Action to perform |
-| `entity` | string | none | Any entity id | **Only valid for `action: more-info` and `action: toggle`** to call `more-info` pop-up for this entity or `toggle` this entity |
+| `action` | string | `toggle` | `popup`, `more-info`, `toggle`, `call-service`, `none`, `navigate`, `url` | Action to perform. `popup` falls back to `more-info` if popup type is not specified |
+| `entity` | string | none | Any entity id | **Only valid for `action: more-info`, `action: popup` and `action: toggle`** to perform an action on the specified entity |
 | `navigation_path` | string | none | Eg: `/lovelace/0/` | Path to navigate to (e.g. `/lovelace/0/`) when action defined as navigate |
 | `url_path` | string | none | Eg: `https://www.google.fr` | URL to open on click when action is `url`. The URL will open in a new tab |
 | `service` | string | none | Any service | Service to call (e.g. `media_player.media_play_pause`) when `action` defined as `call-service` |

--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -584,7 +584,7 @@ class HomeKitCard extends LitElement {
     }
   }
 
-  _customAction(tapAction, entity, row, state) {
+  _customAction(tapAction, entity, row) {
     if (tapAction.confirmation) {
       forwardHaptic("warning");
 

--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -569,15 +569,15 @@ class HomeKitCard extends LitElement {
 
     if ((action == "tap" || action == "doubletap")) {
       if(action == "doubletap" && entity.double_tap_action) {
-        this._customAction(entity.double_tap_action, entity, row, state);
+        this._customAction(entity.double_tap_action, entity, row);
       } else if(entity.tap_action) {
-        this._customAction(entity.tap_action, entity, row, state);
+        this._customAction(entity.tap_action, entity, row);
       } else if(type === "light" || type === "switch" || type === "input_boolean") {
         this._toggle(state, entity.service);
       }
     } else if (action == "pressup") {
       if(entity.hold_action) {
-        this._customAction(entity.hold_action, entity, row, state);
+        this._customAction(entity.hold_action, entity, row);
       } else {
         this._hold(state, entity, row);
       }
@@ -600,7 +600,7 @@ class HomeKitCard extends LitElement {
 
     switch (tapAction.action) {
       case "popup":
-        this._createPopup(state, (tapAction.entity || entity), row);
+        this._createPopup((tapAction.entity || entity.entity), entity, row);
         break;
       case "more-info":
         if (tapAction.entity || tapAction.camera_image) {
@@ -639,31 +639,35 @@ class HomeKitCard extends LitElement {
     return 1;
   }
 
-  _createPopup(stateObj, entity, row) {
-    if(row.popup) {
-        var popUpCard = Object.assign({}, row.popup, { entity: stateObj.entity_id });
-        if(entity.popupExtend) {
-            var popUpCard = Object.assign({}, popUpCard, entity.popupExtend);
-        }
+  _createPopup(entity_id, entity, row) {
+    if((row && row.popup) || entity.popup) {
+      if(row.popup) {
+          var popUpCard = Object.assign({}, row.popup, { entity: entity_id });
+          if(entity.popupExtend) {
+              var popUpCard = Object.assign({}, popUpCard, entity.popupExtend);
+          }
+      } else {
+          var popUpCard = Object.assign({}, entity.popup, { entity: entity_id });
+      }
+      var popUpStyle = {
+          "position": "fixed",
+          "z-index": 999,
+          "top": 0,
+          "left": 0,
+          "height": "100%",
+          "width": "100%",
+          "display": "block",
+          "align-items": "center",
+          "justify-content": "center",
+          "background": "rgba(0, 0, 0, 0.8)",
+          "flex-direction": "column",
+          "margin": 0,
+          "--iron-icon-fill-color": "#FFF"
+      }
+      popUp('', popUpCard, false, popUpStyle);
     } else {
-        var popUpCard = Object.assign({}, entity.popup, { entity: stateObj.entity_id });
+      moreInfo(entity_id)
     }
-    var popUpStyle = {
-        "position": "fixed",
-        "z-index": 999,
-        "top": 0,
-        "left": 0,
-        "height": "100%",
-        "width": "100%",
-        "display": "block",
-        "align-items": "center",
-        "justify-content": "center",
-        "background": "rgba(0, 0, 0, 0.8)",
-        "flex-direction": "column",
-        "margin": 0,
-        "--iron-icon-fill-color": "#FFF"
-    }
-    popUp('', popUpCard, false, popUpStyle);
   }
 
   _toggle(state, service ) {
@@ -673,11 +677,7 @@ class HomeKitCard extends LitElement {
   }
 
   _hold(stateObj, entity, row) {
-    if((row && row.popup) || entity.popup) {
-      this._createPopup(stateObj, entity, row);
-    } else {
-      moreInfo(stateObj.entity_id)
-    }
+    this._createPopup(stateObj.entity_id, entity, row);
   }
   
   _getUnit(measure) {


### PR DESCRIPTION
Adds support for setting the action to "popup" and streamlines the logic in the `_customAction` function. Addresses #41. This allows you to use light-popup-card with tap_action out of the box.

Note: I wasn't able to use ESLint as there isn't an ESLint config file.

Example usage:

```yaml
  - cards:
      - entities:
          - entities:
              - entity: cover.big_garage
                popupExtend:
                  supportedFeaturesTreshold: 8
                tap_action:
                  action: popup
              - entity: switch.porch_light
              - entity: switch.living_room_fan
            popup:
              settings: true
              supportedFeaturesTreshold: -1
              type: 'custom:light-popup-card'
```