### PR TITLE
prevent bottom of entity name being cropped

### DIFF
--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -1055,6 +1055,8 @@ class HomeKitCard extends LitElement {
         color: var(--tile-name-text-color, rgba(0, 0, 0, 0.4));
         width: 100%;
         margin-top: auto;
+        margin-bottom: -5px;
+        padding-bottom: 5px;
         display: -webkit-box;
         -webkit-line-clamp: 2;
         -webkit-box-orient: vertical;


### PR DESCRIPTION
Notice the "tail" of the letter "g".

Before:
![image](https://user-images.githubusercontent.com/2874325/87330395-c044fe00-c4f5-11ea-80d9-04e2d46e35f9.png)

After:
![image](https://user-images.githubusercontent.com/2874325/87330443-d05cdd80-c4f5-11ea-9952-33fce92cc6bc.png)