### PR TITLE
fix unit of measurement css style and remove padding issue on mobile

### DIFF
--- a/dist/homekit-panel-card.js
+++ b/dist/homekit-panel-card.js
@@ -4302,7 +4302,7 @@ class HomeKitCard extends LitElement {
                 style = customCard.dataset.style;
             }
             else if (customCard.dataset.card == 'custom:mini-graph-card') {
-                style = ":host { height: 100%; } ha-card { background: transparent; color: #000; padding: 0!important; box-shadow: none; } .header { padding: 10px 10px 0 10px; } .header .name, .header .name .ellipsis { font-size: 13px!important; font-weight: 500; color: #000; opacity: 1; } .header icon { color: #f7d959; } .states { padding: 0 10px; } .states .state .state__value { font-size: 13px; } .states .state .state__uom { font-size: 13px; } .header .icon { color: #f7d959; }";
+                style = ":host { height: 100%; } ha-card { background: transparent; color: #000; padding: 0!important; box-shadow: none; } .header { padding: 10px 10px 0 10px; } .header .name, .header .name .ellipsis { font-size: 13px!important; font-weight: 500; color: #000; opacity: 1; } .header icon { color: #f7d959; } .states { padding: 0 10px; } .states .state .state__value { font-size: 13px; } .states .state .state__uom { font-size: 13px; margin-top: 0; line-height: normal;  } .header .icon { color: #f7d959; }";
             }
             if (style != "") {
                 let itterations = 0;
@@ -5435,7 +5435,6 @@ class HomeKitCard extends LitElement {
         .header, .card-title, .homekit-card {
           width: 358px;
           text-align: left;
-          padding:0!important;
           margin: 0 auto;
         }
         .card-title {

--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -136,7 +136,7 @@ class HomeKitCard extends LitElement {
       if(customCard.dataset.style) {
         style = customCard.dataset.style;
       } else if(customCard.dataset.card == 'custom:mini-graph-card') {
-        style = ":host { height: 100%; } ha-card { background: transparent; color: #000; padding: 0!important; box-shadow: none; } .header { padding: 10px 10px 0 10px; } .header .name, .header .name .ellipsis { font-size: 13px!important; font-weight: 500; color: #000; opacity: 1; } .header icon { color: #f7d959; } .states { padding: 0 10px; } .states .state .state__value { font-size: 13px; } .states .state .state__uom { font-size: 13px; } .header .icon { color: #f7d959; }";
+        style = ":host { height: 100%; } ha-card { background: transparent; color: #000; padding: 0!important; box-shadow: none; } .header { padding: 10px 10px 0 10px; } .header .name, .header .name .ellipsis { font-size: 13px!important; font-weight: 500; color: #000; opacity: 1; } .header icon { color: #f7d959; } .states { padding: 0 10px; } .states .state .state__value { font-size: 13px; } .states .state .state__uom { font-size: 13px; margin-top: 0; line-height: normal; } .header .icon { color: #f7d959; }";
       }
       if(style!= "") {
         let itterations = 0;
@@ -1272,7 +1272,6 @@ class HomeKitCard extends LitElement {
         .header, .card-title, .homekit-card {
           width: 358px;
           text-align: left;
-          padding:0!important;
           margin: 0 auto;
         }
         .card-title {


### PR DESCRIPTION
Mentioned in #58 the css style for state__uom isn't correct. V0.4.9.5 did improve this, but still had some issues (see screenshot) 
![image](https://user-images.githubusercontent.com/22478441/87707559-99aaef80-c7a1-11ea-9d5d-81aa72a647c9.png)

Also the padding in mobile was wrong as card titles weren't padded and an !important flag in css prevented personal styling.
