### PR TITLE
apply clearfix to parent element to account for float: left on .container

### DIFF
--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -806,6 +806,13 @@ class HomeKitCard extends LitElement {
         --idle-color: #00CC66;
         --unknown-color: #bac;
       }
+
+      :host::after {
+        display: table;
+        content: '';
+        clear: both;
+      }
+
       .card-title {
           margin-bottom:-10px;
           padding-left: 4px;


### PR DESCRIPTION
Without the clearfix, the `homekit-card` element has no height because `.container` has `float: left` on it, and it was causing my simple-thermostat card to consume the height.

![image](https://user-images.githubusercontent.com/2874325/89081942-d6521b80-d349-11ea-9914-d0cc39657763.png)
