### PR TITLE
Add support for showing current position for covers

### DIFF
--- a/src/homekit-panel-card.ts
+++ b/src/homekit-panel-card.ts
@@ -250,6 +250,14 @@ class HomeKitCard extends LitElement {
             <span class=" ${offStates.includes(stateObj.state) ? 'value' : 'value on'}">${this._renderStateValue(ent, stateObj, type)}</span>
           `;
                 }
+            }  else if (type == "cover" && stateObj.attributes.current_position) {
+                if (this.statePositionTop) {
+                    return this._renderCircleState(ent, stateObj, type);
+                } else {
+                    return html`
+            <span class=" ${offStates.includes(stateObj.state) ? 'value' : 'value on'}">${this._renderStateValue(ent, stateObj, type)}</span>
+          `;
+                }
             } else {
                 if (ent.state) {
                     if (this.statePositionTop) {
@@ -265,9 +273,17 @@ class HomeKitCard extends LitElement {
     }
 
     _renderCircleState(ent, stateObj, type) {
+        let value;
+        let valuePercentage;
+        if (type == "cover") {
+          value = stateObj.attributes.current_position;
+          valuePercentage = value;
+        } else {
+          value = stateObj.attributes.brightness;
+          valuePercentage = value / 2.55;
+        }
         return html`
-      <svg class="circle-state" viewbox="0 0 100 100" style="${stateObj.attributes.brightness && !ent.state ? '--percentage:' + (stateObj.attributes.brightness / 2.55)
-            : ''}">
+      <svg class="circle-state" viewbox="0 0 100 100" style="${value && !ent.state ? '--percentage:' + valuePercentage : ''}">
         <path id="progress" stroke-width="3" stroke="#aaabad" fill="none"
               d="M50 10
                 a 40 40 0 0 1 0 80
@@ -312,6 +328,12 @@ class HomeKitCard extends LitElement {
         } else if (type == "climate") {
             return html`
                 ${stateObj.attributes.temperature ? html`${stateObj.attributes.temperature}&#176;` : html``}
+              `;
+        } else if (type == "cover") {
+            return html`
+                ${stateObj.attributes.current_position && !ent.state ? html`${stateObj.attributes.current_position}%` : html``}
+                ${ent.state && !ent.statePath ? html`${computeStateDisplay(this.hass.localize, this.hass.states[ent.state], this.hass.language)}` : html``}
+                ${ent.state && ent.statePath ? html`${this._getValue(ent.state, ent.statePath)}` : html``}
               `;
         } else {
             return html`


### PR DESCRIPTION
Kept _renderCircleState default behaviour to use brightness for any type of entity, except for the new functionality for covers.

Examples with `statePositionTop = true`:

<img width="136" alt="Screenshot 2021-05-06 at 13 16 09" src="https://user-images.githubusercontent.com/6574350/117290662-5cb60380-ae6e-11eb-9596-cdcf784c6c65.png">
<img width="134" alt="Screenshot 2021-05-06 at 13 15 26" src="https://user-images.githubusercontent.com/6574350/117290681-63dd1180-ae6e-11eb-8ed7-ad99939a7636.png">
<img width="134" alt="Screenshot 2021-05-06 at 13 15 06" src="https://user-images.githubusercontent.com/6574350/117290691-65a6d500-ae6e-11eb-84ce-5c75d81984ae.png">

Example with `statePositionTop = false`:
<img width="137" alt="Screenshot 2021-05-06 at 13 16 02" src="https://user-images.githubusercontent.com/6574350/117290674-62134e00-ae6e-11eb-8d98-21d1759758dd.png">
<img width="132" alt="Screenshot 2021-05-06 at 13 14 54" src="https://user-images.githubusercontent.com/6574350/117290701-67709880-ae6e-11eb-9452-67c2e7bf4fb7.png">
